### PR TITLE
build: upgrade Docker to v24.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DOCKER_VERSION=24.0.5
+ARG DOCKER_VERSION=24.0.6
 
 # dind-cleaner
 FROM golang:1.21-alpine3.18 AS cleaner

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.28.1
+version: 1.28.2


### PR DESCRIPTION
## What

This updates base image `docker:24.0.5-dind` → `docker:24.0.6-dind` in order to fix known CVEs.

## Why

Security concerns.

## Notes

—

Fixes #CR-20894