### PR TITLE
fix: change `iptables` backend to legacy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ FROM docker:${DOCKER_VERSION}-dind
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.19/main' >> /etc/apk/repositories \
   && apk upgrade \
   # Add fuse-overlayfs for comaptibility with rootless. Volumes created with rootless might use fuse-overlay formatted volumes. If those volumes are later used by dind that runs with root it'll require fuse-overlay to be able to read the volume
-  && apk add bash fuse-overlayfs jq --no-cache \
+  && apk add bash fuse-overlayfs jq dpkg --no-cache \
   && rm -rf /var/cache/apk/*
+RUN update-alternatives --install $(which iptables) iptables $(which iptables-legacy) 10
 
 COPY --from=node-exporter /bin/node_exporter /bin/
 COPY --from=cleaner /usr/local/bin/dind-cleaner /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ FROM docker:${DOCKER_VERSION}-dind
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.19/main' >> /etc/apk/repositories \
   && apk upgrade \
   # Add fuse-overlayfs for comaptibility with rootless. Volumes created with rootless might use fuse-overlay formatted volumes. If those volumes are later used by dind that runs with root it'll require fuse-overlay to be able to read the volume
-  && apk add bash fuse-overlayfs jq dpkg --no-cache \
+  && apk add bash fuse-overlayfs jq --no-cache \
+  # Needed only for `update-alternatives` below
+  && apk add dpkg --no-cache \
   && rm -rf /var/cache/apk/*
 
 # Backward compatibility with kernels that do not support `iptables-nft`. Check #CR-23033 for details.

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,10 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.19/main' >> /etc/apk/repositor
   # Add fuse-overlayfs for comaptibility with rootless. Volumes created with rootless might use fuse-overlay formatted volumes. If those volumes are later used by dind that runs with root it'll require fuse-overlay to be able to read the volume
   && apk add bash fuse-overlayfs jq dpkg --no-cache \
   && rm -rf /var/cache/apk/*
+
 # Backward compatibility with older containerd. Check #CR-23033 for details.
-RUN update-alternatives --install $(which iptables) iptables $(which iptables-legacy) 10
+RUN update-alternatives --install $(which iptables) iptables $(which iptables-legacy) 10 \
+  && update-alternatives --install $(which ip6tables) ip6tables $(which ip6tables-legacy) 10
 
 COPY --from=node-exporter /bin/node_exporter /bin/
 COPY --from=cleaner /usr/local/bin/dind-cleaner /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.19/main' >> /etc/apk/repositor
   && apk add bash fuse-overlayfs jq dpkg --no-cache \
   && rm -rf /var/cache/apk/*
 
-# Backward compatibility with older containerd. Check #CR-23033 for details.
+# Backward compatibility with kernels that do not support `iptables-nft`. Check #CR-23033 for details.
 RUN update-alternatives --install $(which iptables) iptables $(which iptables-legacy) 10 \
   && update-alternatives --install $(which ip6tables) ip6tables $(which ip6tables-legacy) 10
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.19/main' >> /etc/apk/repositor
   # Add fuse-overlayfs for comaptibility with rootless. Volumes created with rootless might use fuse-overlay formatted volumes. If those volumes are later used by dind that runs with root it'll require fuse-overlay to be able to read the volume
   && apk add bash fuse-overlayfs jq dpkg --no-cache \
   && rm -rf /var/cache/apk/*
+# Backward compatibility with older containerd. Check #CR-23033 for details.
 RUN update-alternatives --install $(which iptables) iptables $(which iptables-legacy) 10
 
 COPY --from=node-exporter /bin/node_exporter /bin/

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.28.4
+version: 1.28.5


### PR DESCRIPTION
## What

This switches `iptables` backend from `iptables-nft` to `legacy` because of compatibility issues with older kernels.

## Why

Fixing compatibility issues.

## Notes

—

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
