### PR TITLE
fix: change `iptables` backend to legacy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,14 @@ RUN echo -en "https://dl-cdn.alpinelinux.org/alpine/v$(cut -d'.' -f1,2 /etc/alpi
   && apk upgrade \
   && apk add bash jq fuse-overlayfs --no-cache \
   && apk add slirp4netns --no-cache \
+  # Needed only for `update-alternatives` below
+  && apk add dpkg --no-cache \
   && rm /usr/local/bin/vpnkit \
   && rm -rf /var/cache/apk/*
+
+# Backward compatibility with kernels that do not support `iptables-nft`. Check #CR-23033 for details.
+RUN update-alternatives --install $(which iptables) iptables $(which iptables-legacy) 10 \
+  && update-alternatives --install $(which ip6tables) ip6tables $(which ip6tables-legacy) 10
 
 ENV DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns
 

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.28.4
+version: 1.28.5


### PR DESCRIPTION
## What

This switches `iptables` backend from `iptables-nft` to `legacy` because of compatibility issues with older kernels.

## Why

Fixing compatibility issues.

## Notes

—

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
