### PR TITLE
build: upgrade Docker to v26.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG DOCKER_VERSION=26.0.0
+ARG DOCKER_VERSION=26.1.4
 
 # dind-cleaner
-FROM golang:1.22-alpine3.19 AS cleaner
+FROM golang:1.22-alpine3.20 AS cleaner
 
 COPY cleaner/dind-cleaner/* /go/src/github.com/codefresh-io/dind-cleaner/
 WORKDIR /go/src/github.com/codefresh-io/dind-cleaner/
@@ -15,11 +15,11 @@ RUN CGO_ENABLED=0 go build -o /usr/local/bin/dind-cleaner ./cmd && \
   rm -rf /go/*
 
 # bbolt
-FROM golang:1.22-alpine3.19 AS bbolt
+FROM golang:1.22-alpine3.20 AS bbolt
 RUN go install go.etcd.io/bbolt/cmd/bbolt@latest
 
 # node-exporter
-FROM quay.io/prometheus/node-exporter:v1.7.0 AS node-exporter
+FROM quay.io/prometheus/node-exporter:v1.8.1 AS node-exporter
 
 # Main
 FROM docker:${DOCKER_VERSION}-dind-rootless

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.28.6
+version: 1.28.7


### PR DESCRIPTION
## What

This upgrades Docker and some other base images to the most recent versions.

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
