### PR TITLE
fix: rootless dind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ ADD . /dind
 
 RUN chown -R $(id -u rootless) /dind
 RUN chown -R $(id -u rootless) /var/run
+RUN chown -R $(id -u rootless) /run/user
 
 RUN chown -R $(id -u rootless) /etc/ssl && chmod 777 -R /etc/ssl
 USER rootless

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.28.8
+version: 1.28.9


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
