### PR TITLE
fix(dind-rootless): remove symlink 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ ADD . /dind
 
 RUN chown -R $(id -u rootless) /dind
 RUN chown -R $(id -u rootless) /var/run
-RUN chown -R $(id -u rootless) /run/user/1000
 
 RUN chown -R $(id -u rootless) /etc/ssl && chmod 777 -R /etc/ssl
 USER rootless

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ ADD . /dind
 
 RUN chown -R $(id -u rootless) /dind
 RUN chown -R $(id -u rootless) /var/run
+RUN chown -R $(id -u rootless) /run/user
 
 RUN chown -R $(id -u rootless) /etc/ssl && chmod 777 -R /etc/ssl
 USER rootless

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,5 +57,8 @@ RUN chown -R $(id -u rootless) /run/user
 
 RUN chown -R $(id -u rootless) /etc/ssl && chmod 777 -R /etc/ssl
 USER rootless
-RUN rm -i -f /var/run && ln -s /run/user/1000 /var/run
+RUN rm -i -f /var/run && \
+  ln -s /run/user/1000 /var/run && \
+  ln -s /run/user/1000/docker.pid /var/run/docker.pid && \
+  ln -s /run/user/1000/docker.sock /var/run/docker.sock 
 ENTRYPOINT ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,12 +53,8 @@ ADD . /dind
 
 RUN chown -R $(id -u rootless) /dind
 RUN chown -R $(id -u rootless) /var/run
-RUN chown -R $(id -u rootless) /run/user
 
 RUN chown -R $(id -u rootless) /etc/ssl && chmod 777 -R /etc/ssl
 USER rootless
-RUN rm -i -f /var/run && \
-  ln -s /run/user/1000 /var/run && \
-  ln -s /run/user/1000/docker.pid /var/run/docker.pid && \
-  ln -s /run/user/1000/docker.sock /var/run/docker.sock 
+RUN rm -i -f /var/run && ln -s /run/user/1000 /var/run
 ENTRYPOINT ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ ADD . /dind
 
 RUN chown -R $(id -u rootless) /dind
 RUN chown -R $(id -u rootless) /var/run
+RUN chown -R $(id -u rootless) /run/user/1000
 
 RUN chown -R $(id -u rootless) /etc/ssl && chmod 777 -R /etc/ssl
 USER rootless
-RUN rm -i -f /var/run && ln -s /run/user/1000 /var/run
 ENTRYPOINT ["./run.sh"]

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.28.8
+version: 1.28.9


### PR DESCRIPTION
## What

Remove symlink `/var/run -> /run/user/1000`

## Why

We have an option in cf-runtime helm chart to override docker `daemon.json` config instead

```yaml
  runtime:
    dindDaemon:
      hosts:
        - unix:///run/user/1000/docker.sock
        - tcp://0.0.0.0:1300
```


## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
