### PR TITLE
fix: rootless dind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,13 @@ RUN chown -R $(id -u rootless) /dind
 RUN chown -R $(id -u rootless) /var/run
 
 RUN chown -R $(id -u rootless) /etc/ssl && chmod 777 -R /etc/ssl
-USER rootless
 RUN rm -i -f /var/run && ln -s /run/user/1000 /var/run
+
+RUN set -eux; \
+	mkdir -p /home/rootless/.local/share/docker; \
+	chown -R rootless:rootless /home/rootless/.local/share/docker
+
+VOLUME /home/rootless/.local/share/docker
+USER rootless
+
 ENTRYPOINT ["./run.sh"]

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.28.10
+version: 1.28.11


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
