### PR TITLE
fix: add cgroup wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ COPY --from=bbolt /go/bin/bbolt /bin/
 WORKDIR /dind
 ADD . /dind
 
-ENTRYPOINT ["./run.sh"]
+ENTRYPOINT ["./wrapper.sh"]

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 3.0.2
+version: 3.0.3

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+apk add --no-cache util-linux \
+  && unshare --cgroup /bin/sh -c 'umount /sys/fs/cgroup && mount -t cgroup2 cgroup /sys/fs/cgroup && /dind/run.sh "$0" "$@"'
+  "$0" "$@"


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
