### PR TITLE
fix: rootless cgroups v2

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -189,9 +189,24 @@ do
   fi
 
   echo "Starting dockerd rootless"
-  #dockerd ${DOCKERD_PARAMS} <&- &
-  export DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="-p 0.0.0.0:1300:1300/tcp" # Expose rooltelsskit port
-  dockerd-entrypoint.sh dockerd ${DOCKERD_PARAMS} <&- &
+  if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+    echo "Using cgroup v1"
+    dockerd ${DOCKERD_PARAMS} <&- &
+  else
+    echo "Using cgroup v2"
+
+    CURRENT_CGROUP=$(cat /proc/self/cgroup | sed 's/0:://')
+    echo "Current cgroup: ${CURRENT_CGROUP}"
+    CONTAINER_OOM_GROUP="/sys/fs/cgroup/${CURRENT_CGROUP}/memory.oom.group"
+    echo "cgroup ${CONTAINER_OOM_GROUP} value: $(cat "${CONTAINER_OOM_GROUP}")"
+    echo "Changing ${CONTAINER_OOM_GROUP} to 0 to disable killing all processes in cgroup on OOM"
+    echo "0" > "${CONTAINER_OOM_GROUP}"
+    echo "cgroup ${CONTAINER_OOM_GROUP} value: $(cat "${CONTAINER_OOM_GROUP}")"
+
+    #dockerd ${DOCKERD_PARAMS} <&- &
+    export DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="-p 0.0.0.0:1300:1300/tcp" # Expose rooltelsskit port
+    dockerd-entrypoint.sh dockerd ${DOCKERD_PARAMS} <&- &
+  fi
 
   echo "Waiting at most 20s for docker pid"
   CNT=0


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
