### PR TITLE
chore(CR-36677): update version of docker to v29.4.0, update node_exporter to 1.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CI relies on this ARG. Don't remove or rename it
-ARG DOCKER_VERSION=29.2.0
+ARG DOCKER_VERSION=29.4.0
 
 # dind-cleaner
 FROM golang:1.25-alpine3.23 AS cleaner
@@ -37,7 +37,7 @@ RUN update-alternatives --install $(which iptables) iptables $(which iptables-le
   && update-alternatives --install $(which ip6tables) ip6tables $(which ip6tables-legacy) 10
 ENV DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-node-exporter
-COPY --from=docker.io/octopusdeploy/dhi-node-exporter:1.10.2@sha256:d8f7da5fb79a2df6dc449eec10ad786a02169c45d081730252b162d072a52eb3 /usr/local/bin/node_exporter /bin/
+COPY --from=docker.io/octopusdeploy/dhi-node-exporter:1.11.0-alpine3.23@sha256:0354dfb8ecb38d3678e554e25f6d7fdcee0e38bdedcfdda85e46e094a498dda4 /usr/bin/node_exporter /bin/
 COPY --from=bbolt /go/bin/bbolt /bin/
 COPY --from=cleaner /usr/local/bin/dind-cleaner /bin/
 WORKDIR /dind

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 3.0.12
+version: 3.0.13


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build


<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. ↓↓↓ ⚠️ -->
## Security Report

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/dev/dind:cr-36677-security-rootless@sha256:31325ac7db2a8faff27b96e27ee6294276b1df31a1f7ae45d2b18df11edd0f87](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A31325ac7db2a8faff27b96e27ee6294276b1df31a1f7ae45d2b18df11edd0f87)
>
> **Baseline**:
[quay.io/codefresh/dind:rootless@sha256:5eb67e301287a8805a997f1ad31a66dfb009c5c4da6348b59598de344cad00b9](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A5eb67e301287a8805a997f1ad31a66dfb009c5c4da6348b59598de344cad00b9)

> [!IMPORTANT]
> Current summary is in beta mode.
> Please analyze [the full scan report](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A31325ac7db2a8faff27b96e27ee6294276b1df31a1f7ae45d2b18df11edd0f87) for comprehensive details.

### Fixed CVEs: 23
#### 🟣 Critical: 3
- CVE-2025-68121 in `crypto/tls@1.25.6` at `/usr/local/bin/containerd`
- CVE-2025-68121 in `crypto/tls@1.24.12` at `/bin/node_exporter`
- CVE-2025-68121 in `crypto/tls@1.24.11` at `/usr/local/libexec/docker/cli-plugins/docker-compose`
#### 🔴 High: 2
- CVE-2025-66564 in `github.com/sigstore/timestamp-authority/v2@v2.0.2` at `/usr/local/bin/dockerd`
- CVE-2025-61726 in `net/url@1.24.11` at `/usr/local/libexec/docker/cli-plugins/docker-compose`
#### 🟠 Medium: 8
- GHSA-xmrv-pmrh-hhx2 in `github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream@v1.7.4` at `/usr/local/bin/dockerd`
- GHSA-xmrv-pmrh-hhx2 in `github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs@v1.63.1` at `/usr/local/bin/dockerd`
- CVE-2026-23992 in `github.com/theupdateframework/go-tuf/v2@v2.3.0` at `/usr/local/bin/dockerd`
- CVE-2026-23991 in `github.com/theupdateframework/go-tuf/v2@v2.3.0` at `/usr/local/bin/dockerd`
- CVE-2026-24117 in `github.com/sigstore/rekor@v1.4.3` at `/usr/local/libexec/docker/cli-plugins/docker-buildx`
- CVE-2026-23831 in `github.com/sigstore/rekor@v1.4.3` at `/usr/local/libexec/docker/cli-plugins/docker-buildx`
- CVE-2025-61730 in `crypto/tls@1.24.11` at `/usr/local/libexec/docker/cli-plugins/docker-compose`
- CVE-2026-24686 in `github.com/theupdateframework/go-tuf/v2@v2.3.0` at `/usr/local/bin/dockerd`
#### 🟡 Low: 1
- CVE-2026-1229 in `github.com/cloudflare/circl@v1.6.1` at `/usr/local/bin/dockerd`
#### ⚫ Unassigned: 9
- CVE-2026-25679 in `net/url@1.24.12` at `/bin/node_exporter`
- CVE-2026-25679 in `net/url@1.24.11` at `/usr/local/libexec/docker/cli-plugins/docker-compose`
- CVE-2026-25679 in `net/url@1.25.6` at `/usr/local/bin/containerd`
- CVE-2026-27142 in `html/template@1.24.12` at `/bin/node_exporter`
- CVE-2026-27142 in `html/template@1.24.11` at `/usr/local/libexec/docker/cli-plugins/docker-compose`
- CVE-2026-27142 in `html/template@1.25.6` at `/usr/local/bin/containerd`
- CVE-2026-27139 in `os@1.24.12` at `/bin/node_exporter`
- CVE-2026-27139 in `os@1.24.11` at `/usr/local/libexec/docker/cli-plugins/docker-compose`
- CVE-2026-27139 in `os@1.25.6` at `/usr/local/bin/containerd`

<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. ↑↑↑ ⚠️ -->
