### PR TITLE
fix(security): update docker; update DHI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CI relies on this ARG. Don't remove or rename it
-ARG DOCKER_VERSION=29.5.2
+ARG DOCKER_VERSION=29.5.3
 
 # dind-cleaner
 FROM golang:1.26-alpine3.23 AS cleaner
@@ -31,7 +31,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.23/main' >> /etc/apk/repositor
 RUN update-alternatives --install $(which iptables) iptables $(which iptables-legacy) 10 \
   && update-alternatives --install $(which ip6tables) ip6tables $(which ip6tables-legacy) 10
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-node-exporter
-COPY --from=docker.io/octopusdeploy/dhi-node-exporter:1.11.1-alpine3.23@sha256:8cd8b3f56f6c319a03c7a2224e99d07e34241ae9ced308df5a6fee41d61ea905 /usr/bin/node_exporter /bin/
+COPY --from=docker.io/octopusdeploy/dhi-node-exporter:1.11.1-alpine3.23@sha256:624ca0512dee2db60eeb20ccb23ccd5310f743449987eb8b2fce2e38f5f6d7be /usr/bin/node_exporter /bin/
 COPY --from=bbolt /go/bin/bbolt /bin/
 COPY --from=cleaner /usr/local/bin/dind-cleaner /bin/
 

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 3.0.16
+version: 3.0.17


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build


<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. ↓↓↓ ⚠️ -->
## Security Report

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/dev/dind:cr-40963-security@sha256:10cd015610e07205fbb9a9cdcfc55dd35e4a31a26ae8cf0ba0bc4cf957f73720](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A10cd015610e07205fbb9a9cdcfc55dd35e4a31a26ae8cf0ba0bc4cf957f73720)
>
> **Baseline**:
[quay.io/codefresh/dind:master@sha256:2f1c98c179b39ab51b1541887b3edd02c2605f3a0c940c3814ae2f42b14bdbd7](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A2f1c98c179b39ab51b1541887b3edd02c2605f3a0c940c3814ae2f42b14bdbd7)

> [!IMPORTANT]
> Current summary is in beta mode.
> Please analyze [the full scan report](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A10cd015610e07205fbb9a9cdcfc55dd35e4a31a26ae8cf0ba0bc4cf957f73720) for comprehensive details.

### Fixed CVEs: 5
#### 🔴 High: 2
- CVE-2026-39836 in `net@1.26.2` at `/bin/node_exporter`
- CVE-2026-34986 in `github.com/go-jose/go-jose/v4@v4.1.3` at `/usr/local/bin/containerd`
#### 🟠 Medium: 2
- CVE-2026-39826 in `html/template@1.26.2` at `/bin/node_exporter`
- CVE-2026-39823 in `html/template@1.26.2` at `/bin/node_exporter`
#### ⚫ Unassigned: 1
- CVE-2026-39821 in `golang.org/x/net/idna@v0.54.0` at `/usr/local/bin/dockerd`


[🔗 View all related Jira tickets](https://codefresh-io.atlassian.net/jira/software/c/projects/CR/issues?jql=project%20%3D%20CR%20AND%20%22security%20image%5Bshort%20text%5D%22%20~%20%22dind%22%20AND%20(%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-39836%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-34986%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-39826%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-39823%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-39821%22)%20ORDER%20BY%20created%20ASC)

<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. ↑↑↑ ⚠️ -->
