### PR TITLE
fix(docker-cleaner): negotiate API version

### DIFF
--- a/cleaner/dind-cleaner/cmd/main.go
+++ b/cleaner/dind-cleaner/cmd/main.go
@@ -70,9 +70,6 @@ func _stringInList(list []string, s string) bool {
 
 func cleanImages(retainedImagesList []string, retainPeriod int64) {
 	glog.Infof("Entering cleanImages, length of retainedImagesList = %d", len(retainedImagesList))
-	if os.Getenv("DOCKER_API_VERSION") == "" {
-		os.Setenv("DOCKER_API_VERSION", "1.35")
-	}
 
 	cli, err := client.New(
 		client.FromEnv,

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 3.0.22
+version: 3.0.23


### PR DESCRIPTION
## What

This PR fixes a panic in `dind-cleaner` when running against docker daemons on a newer API version. The cleaner defaulted `DOCKER_API_VERSION` to `1.35` whenever the env var wasn't set, which disabled the docker client's automatic API version negotiation and caused it to fail with `client version 1.35 is too old. Minimum supported API version is 1.40`.

This PR proposes removing the hardcoded default version, letting the docker client (`github.com/moby/moby/client`) negotiate the API version automatically, as it does by default when `DOCKER_API_VERSION` is unset. If the env var is explicitly set, that value is still honored.

Rootless variant: https://github.com/codefresh-io/dind/pull/151

Closes [CF-2254](https://linear.app/octopus/issue/CF-2254/classic-runtime-is-using-deprecated-docker-api)

## PR Comments

Add the following comments to the PR:

* `/e2e` - to trigger E2E build
* `/bump patch` - to bump the patch version
* `/bump minor` - to bump the minor version
* `/bump major` - to bump the major version

[CF-2254]: https://codefresh-io.atlassian.net/browse/CF-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/dind~ ↓↓↓ ⚠️ -->

## Security Report — codefresh/dind

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/dev/dind:zhenyatikhonovcf-2254-classic-runtime-is-using-deprecated-docker-api@sha256:9ab263c39ced3a23d8edd23f483de2435963226adaee07d5c5155fdb68400b6a](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A9ab263c39ced3a23d8edd23f483de2435963226adaee07d5c5155fdb68400b6a)
>
> **Baseline**:
[quay.io/codefresh/dind:master@sha256:2c848347cf77a2094cc6c674f28f956e0d97057279dd9be4dbf92f5e98c05e45](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A2c848347cf77a2094cc6c674f28f956e0d97057279dd9be4dbf92f5e98c05e45)

### Fixed CVEs: 0

### Fixed issues: 0


<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/dind~ ↑↑↑ ⚠️ -->
