### PR TITLE
chore: update docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go install go.etcd.io/bbolt/cmd/bbolt@latest
 FROM octopusdeploy/dhi-node-exporter:1.12.1-alpine3.24@sha256:e77ce1d3ff7a7dfb56dfda8f6485a14f8ab6aecb2d85fa37c6a2fdf41f71ed83 AS node-exporter
 
 
-FROM docker:29.6.1-dind@sha256:66d292e5c26bd33a6f6f61cacb880de2186339a524ecba1ce098dbbaceed6515 AS prod
+FROM docker:29.6.2-dind@sha256:bfec1f5159c63a81ca6fdedbd81404d2c0e16378ed0feec3bb3fbf3998847659 AS prod
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.24/main' >> /etc/apk/repositories \
   && apk upgrade && apk add --no-cache \
     bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-golang
-FROM octopusdeploy/dhi-golang:1.26-alpine3.24-dev@sha256:29fe0a7d2a5ab0c236fbde3a7f63801755585ed260b6f2f564e831c92bfa9f34 AS cleaner
+FROM octopusdeploy/dhi-golang:1.26-alpine3.24-dev@sha256:753793e50e16daafaf70566409c752ed05f177fb34ad5b488918bbccae462413 AS cleaner
 COPY cleaner/dind-cleaner/* /go/src/github.com/codefresh-io/dind-cleaner/
 WORKDIR /go/src/github.com/codefresh-io/dind-cleaner/
 RUN go mod tidy
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 go build -o /usr/local/bin/dind-cleaner ./cmd \
 
 
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-golang
-FROM octopusdeploy/dhi-golang:1.26-alpine3.24-dev@sha256:29fe0a7d2a5ab0c236fbde3a7f63801755585ed260b6f2f564e831c92bfa9f34 AS bbolt
+FROM octopusdeploy/dhi-golang:1.26-alpine3.24-dev@sha256:753793e50e16daafaf70566409c752ed05f177fb34ad5b488918bbccae462413 AS bbolt
 RUN go install go.etcd.io/bbolt/cmd/bbolt@latest
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,12 @@ FROM octopusdeploy/dhi-node-exporter:1.12.1-alpine3.24@sha256:e77ce1d3ff7a7dfb56
 
 FROM docker:29.6.1-dind@sha256:66d292e5c26bd33a6f6f61cacb880de2186339a524ecba1ce098dbbaceed6515 AS prod
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.24/main' >> /etc/apk/repositories \
+  && echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
   && apk upgrade && apk add --no-cache \
     bash \
     # Add fuse-overlayfs for compatibility with rootless. Volumes created with rootless might use fuse-overlay formatted volumes. If those volumes are later used by dind that runs with root it'll require fuse-overlay to be able to read the volume
     fuse-overlayfs \
-    jq \
+    jq@edge \
     # Needed only for `update-alternatives` below
     dpkg
 # Backward compatibility with kernels that do not support `iptables-nft`. Check #CR-23033 for details.

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 3.0.22
+version: 3.0.23

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 3.0.23
+version: 3.0.24


### PR DESCRIPTION
## What

<!--
Describe the changes briefly yet comprehensively.
Link relevant Linear issues, e.g.:
Closes CF-1234
-->

## PR Comments

Add the following comments to the PR:

* `/e2e` - to trigger E2E build
* `/bump patch` - to bump the patch version
* `/bump minor` - to bump the minor version
* `/bump major` - to bump the major version

<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/dind~ ↓↓↓ ⚠️ -->

## Security Report — codefresh/dind

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/dev/dind:cfs-7171-security@sha256:385f0c52371079a55302e65fdc7e790e7a58994a65a4e59805be013cf17a836e](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A385f0c52371079a55302e65fdc7e790e7a58994a65a4e59805be013cf17a836e)
>
> **Baseline**:
[quay.io/codefresh/dind:master@sha256:9ab263c39ced3a23d8edd23f483de2435963226adaee07d5c5155fdb68400b6a](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A9ab263c39ced3a23d8edd23f483de2435963226adaee07d5c5155fdb68400b6a)

### Fixed CVEs: 8
#### 🔴 High: 1
- CVE-2026-32316 in `jq@1.8.1-r0` at `unknown path`
#### 🟠 Medium: 5
- CVE-2026-43896 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-43894 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-41257 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-40612 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-33947 in `jq@1.8.1-r0` at `unknown path`
#### 🟡 Low: 2
- CVE-2026-43895 in `jq@1.8.1-r0` at `unknown path`
- CVE-2026-41256 in `jq@1.8.1-r0` at `unknown path`

### Fixed issues: 2
<!-- Fixed issues: ~[{"identifier":"CFS-7184","dueDate":"2026-08-12"},{"identifier":"CFS-7171","dueDate":"2026-08-12"}]~ -->
- Fixes [CFS-7184](https://linear.app/octopus/issue/CFS-7184/security-codefreshdind-cve-2026-43895-low)
- Fixes [CFS-7171](https://linear.app/octopus/issue/CFS-7171/security-codefreshdind-cve-2026-41256-low)

<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/dind~ ↑↑↑ ⚠️ -->


